### PR TITLE
Feat: 홈화면 UI 구현

### DIFF
--- a/src/pages/home/page/Home.css.ts
+++ b/src/pages/home/page/Home.css.ts
@@ -1,0 +1,120 @@
+import { style } from '@vanilla-extract/css';
+import { colors } from '@/styles/token/color.css.ts';
+import { fonts } from '@/styles/token/typography.css.ts';
+
+export const container = style({
+  width: '100%',
+  maxWidth: '430px',
+  margin: '0 auto',
+  padding: '20px 20px 32px', // 좌우 여백 조금 줄임
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px', // 블록 간 간격 줄임
+  background: colors.grey11,
+  minHeight: '100dvh',
+  boxSizing: 'border-box',
+  alignItems: 'center', // 내부 블록 가운데 정렬
+});
+
+/* 날짜 & 인사 */
+export const dateSection = style({
+  width: '90%', // 전체 폭보다 좁게
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+});
+
+export const date = style({
+  ...fonts.body01,
+  color: colors.grey01,
+});
+
+export const greeting = style({
+  ...fonts.caption02,
+  color: colors.grey07,
+});
+
+/* 날씨 카드 */
+export const weatherCard = style({
+  width: '90%', // 폭 축소
+  background: colors.blue07,
+  color: colors.white01,
+  borderRadius: '12px',
+  padding: '18px 20px', // 패딩 줄임
+  display: 'flex',
+  marginBottom: '10px',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+});
+
+export const weatherLeft = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2px',
+});
+
+export const city = style({
+  ...fonts.body02,
+  color: colors.white01,
+});
+
+export const weather = style({
+  ...fonts.caption02,
+  color: colors.white01,
+  opacity: 0.9,
+});
+
+export const temp = style({
+  ...fonts.subtitle04,
+  color: colors.white01,
+});
+
+/* 메뉴 2x2 */
+export const menuGrid = style({
+  width: '90%', // 전체 폭 줄임
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '20px', // 블록 간격 줄임
+  marginTop: '4px',
+});
+
+export const menuItem = style({
+  background: colors.white01,
+  border: `1px solid ${colors.grey11}`,
+  borderRadius: '10px',
+  width: '100%',
+  aspectRatio: '0.6 / 0.7', // 너비 대비 세로가 더 긴 비율
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '8px',
+  boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+  cursor: 'pointer',
+  transition: 'transform .08s ease, box-shadow .12s ease',
+  selectors: {
+    '&:active': {
+      transform: 'scale(0.98)',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+  },
+});
+
+export const menuIcon = style({
+  fontSize: '24px', // 아이콘 크기 줄임
+  lineHeight: 1,
+  color: colors.blue07,
+});
+
+export const menuLabel = style({
+  ...fonts.body04,
+  color: colors.grey02,
+});
+
+/* (SVG 아이콘을 쓸 때) */
+export const menuSvg = style({
+  width: '24px',
+  height: '24px',
+  fill: colors.blue07,
+});

--- a/src/pages/home/page/Home.tsx
+++ b/src/pages/home/page/Home.tsx
@@ -1,8 +1,55 @@
+// src/pages/home/page/Home.tsx
+import * as styles from './Home.css.ts';
+
 const Home = () => {
   return (
-    <>
-      <h1>Home</h1>
-    </>
+    <div className={styles.container}>
+      {/* 날짜 & 인사말 */}
+      <section className={styles.dateSection}>
+        <p className={styles.date}>2025년 7월 14일 금요일</p>
+        <p className={styles.greeting}>좋은 아침이에요!!</p>
+      </section>
+
+      {/* 날씨 카드 */}
+      <section className={styles.weatherCard}>
+        <div className={styles.weatherLeft}>
+          <p className={styles.city}>서울시</p>
+          <p className={styles.weather}>맑음</p>
+        </div>
+        <p className={styles.temp}>27℃</p>
+      </section>
+
+      {/* 메뉴 4칸 (2x2) */}
+      <section className={styles.menuGrid}>
+        <button className={styles.menuItem} type="button">
+          <span className={styles.menuIcon} aria-hidden>
+            💬
+          </span>
+          <span className={styles.menuLabel}>채팅</span>
+        </button>
+
+        <button className={styles.menuItem} type="button">
+          <span className={styles.menuIcon} aria-hidden>
+            🔁
+          </span>
+          <span className={styles.menuLabel}>회상 기록</span>
+        </button>
+
+        <button className={styles.menuItem} type="button">
+          <span className={styles.menuIcon} aria-hidden>
+            📅
+          </span>
+          <span className={styles.menuLabel}>일정</span>
+        </button>
+
+        <button className={styles.menuItem} type="button">
+          <span className={styles.menuIcon} aria-hidden>
+            🎮
+          </span>
+          <span className={styles.menuLabel}>게임</span>
+        </button>
+      </section>
+    </div>
   );
 };
 


### PR DESCRIPTION
# 🐣 Pull requests

### 📍 작업한 이슈번호

- #15 

### 💻 작업한 내용

- Home 페이지 레이아웃 및 스타일 구현
- 날짜/인사말 영역 추가
- 날씨 카드 UI 구성
- 채팅/회상기록/일정/게임 메뉴 4칸 레이아웃
- 디자인 비율 및 간격 조정

- `src/pages/home/page/Home.tsx` 생성
- `src/pages/home/page/Home.css.ts` 생성
- 색상, 폰트 토큰 적용

### 📢 PR Point

- 아이콘 수정해야함

### 📸 스크린샷
<img width="587" height="867" alt="image" src="https://github.com/user-attachments/assets/33749e42-68d2-474c-a796-106bb8a7cac8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 홈 화면을 대시보드 형태로 개편: 날짜/인사말, 날씨 카드(도시·날씨·기온), 2x2 메뉴 그리드(채팅, 회상, 일정, 게임) 추가.
* 스타일
  * 카드 기반 레이아웃과 중앙 정렬 적용, 최대 너비 430px 및 화면 높이 맞춤.
  * 메뉴 카드에 그림자·테두리·호버/활성화 효과 추가로 상호작용성 향상.
  * 아이콘·라벨 가독성 개선, 간격과 타이포그래피 정돈.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->