### PR TITLE
Feat: 채팅화면 헤더 구현

### DIFF
--- a/public/svgs/ic_hamburger.svg
+++ b/public/svgs/ic_hamburger.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 9H17M1 17H17M1 1H17" stroke="#212525" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/common/components/header/ChatHeader.tsx
+++ b/src/common/components/header/ChatHeader.tsx
@@ -1,0 +1,57 @@
+// src/common/components/header/ChatHeader.tsx
+import { useNavigate } from 'react-router-dom';
+
+import * as styles from './PageHeader.css';
+
+import { IcBack } from '@/assets/svgs';
+
+type ChatHeaderProps = {
+  title?: string;
+  onBack?: () => void;
+  onMenuClick?: () => void;
+};
+
+const ChatHeader = ({ title = '채팅', onBack, onMenuClick }: ChatHeaderProps) => {
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    if (onBack) {
+      return onBack();
+    }
+    navigate(-1);
+  };
+
+  return (
+    <header className={styles.header}>
+      {/* 좌측: 뒤로가기 (PageHeader와 동일) */}
+      <button onClick={handleBack} aria-label="뒤로가기">
+        <IcBack className={styles.backButton} />
+      </button>
+
+      {/* 중앙: 타이틀 (PageHeader와 동일) */}
+      <h1 className={styles.title}>{title}</h1>
+
+      {/* 우측: 햄버거 (public/svgs/ic_hamburger.svg) */}
+      <button
+        onClick={onMenuClick}
+        aria-label="메뉴"
+        style={{
+          position: 'absolute',
+          top: '50%',
+          right: '1.6rem',
+          transform: 'translateY(-50%)',
+          width: '1.55rem',
+          height: '1.55rem',
+          border: 'none',
+          background: 'transparent',
+          cursor: 'pointer',
+          padding: 0,
+        }}
+      >
+        <img src="/svgs/ic_hamburger.svg" alt="메뉴" style={{ width: '100%', height: '100%' }} />
+      </button>
+    </header>
+  );
+};
+
+export default ChatHeader;

--- a/src/pages/chat/page/Chat.tsx
+++ b/src/pages/chat/page/Chat.tsx
@@ -1,0 +1,13 @@
+// src/pages/chat/page/Chat.tsx
+import * as React from 'react';
+
+const Chat = () => {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>채팅 화면</h1>
+      <p>여기에 채팅 UI를 구현하면 돼!</p>
+    </div>
+  );
+};
+
+export default Chat;

--- a/src/pages/chat/page/Chat.tsx
+++ b/src/pages/chat/page/Chat.tsx
@@ -1,5 +1,4 @@
 // src/pages/chat/page/Chat.tsx
-import * as React from 'react';
 
 const Chat = () => {
   return (

--- a/src/pages/home/page/Home.tsx
+++ b/src/pages/home/page/Home.tsx
@@ -1,7 +1,10 @@
 // src/pages/home/page/Home.tsx
+import { useNavigate } from 'react-router-dom';
 import * as styles from './Home.css.ts';
 
 const Home = () => {
+  const navigate = useNavigate();
+
   return (
     <div className={styles.container}>
       {/* 날짜 & 인사말 */}
@@ -21,29 +24,33 @@ const Home = () => {
 
       {/* 메뉴 4칸 (2x2) */}
       <section className={styles.menuGrid}>
-        <button className={styles.menuItem} type="button">
-          <span className={styles.menuIcon} aria-hidden>
+        {/* 채팅 */}
+        <button className={styles.menuItem} type="button" onClick={() => navigate('/chat')}>
+          <span className={styles.menuIcon} aria-hidden={true}>
             💬
           </span>
           <span className={styles.menuLabel}>채팅</span>
         </button>
 
+        {/* 회상 기록 */}
         <button className={styles.menuItem} type="button">
-          <span className={styles.menuIcon} aria-hidden>
+          <span className={styles.menuIcon} aria-hidden={true}>
             🔁
           </span>
           <span className={styles.menuLabel}>회상 기록</span>
         </button>
 
+        {/* 일정 */}
         <button className={styles.menuItem} type="button">
-          <span className={styles.menuIcon} aria-hidden>
+          <span className={styles.menuIcon} aria-hidden={true}>
             📅
           </span>
           <span className={styles.menuLabel}>일정</span>
         </button>
 
+        {/* 게임 */}
         <button className={styles.menuItem} type="button">
-          <span className={styles.menuIcon} aria-hidden>
+          <span className={styles.menuIcon} aria-hidden={true}>
             🎮
           </span>
           <span className={styles.menuLabel}>게임</span>

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -4,6 +4,7 @@ export const PATH = {
   LOGIN: '/login',
   REMINISCE: '/reminisce',
   MYPAGE: '/mypage',
+  CHAT: '/chat',
 } as const;
 
 export const SIGNUP_STEPS = {

--- a/src/shared/routes/MainRoutes.tsx
+++ b/src/shared/routes/MainRoutes.tsx
@@ -3,6 +3,7 @@ import { Navigate } from 'react-router-dom';
 import { PATH } from '@shared/constants/path';
 import Layout from '@shared/components/layout/Layout';
 
+import ChatHeader from '@/common/components/header/ChatHeader';
 import PageHeader from '@/common/components/header/PageHeader';
 import Header from '@/common/components/header/Header';
 import Home from '@/pages/home/page/Home';
@@ -56,9 +57,9 @@ export const MainRoutes: RouteObject[] = [
     children: [{ path: PATH.MYPAGE, element: <MyPage /> }],
   },
 
-  //채팅
+  // 채팅 — 여기만 전용 헤더 사용
   {
-    element: <Layout header={<PageHeader title="채팅" />} />,
+    element: <Layout header={<ChatHeader title="채팅" />} />,
     children: [{ path: PATH.CHAT, element: <Chat /> }],
   },
 ];

--- a/src/shared/routes/MainRoutes.tsx
+++ b/src/shared/routes/MainRoutes.tsx
@@ -15,6 +15,7 @@ import ReminisceList from '@/pages/reminisce/page/ReminisceList';
 import ReminisceWrite from '@/pages/reminisce/page/ReminisceWrite';
 import ReminisceDetail from '@/pages/reminisce/page/ReminisceDetail';
 import MyPage from '@/pages/mypage/page/MyPage';
+import Chat from '@/pages/chat/page/Chat';
 
 export const MainRoutes: RouteObject[] = [
   // 기본 헤더
@@ -53,5 +54,11 @@ export const MainRoutes: RouteObject[] = [
   {
     element: <Layout header={<PageHeader title="마이페이지" />} />,
     children: [{ path: PATH.MYPAGE, element: <MyPage /> }],
+  },
+
+  //채팅
+  {
+    element: <Layout header={<PageHeader title="채팅" />} />,
+    children: [{ path: PATH.CHAT, element: <Chat /> }],
   },
 ];


### PR DESCRIPTION
# 🐣 Pull requests

### 📍 작업한 이슈번호

- #22 

### 💻 작업한 내용

- 채팅화면 헤더 생성

### 📢 PR Point

-

### 📸 스크린샷

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅 화면(초기 버전) 추가: 채팅 본문(플레이스홀더) 및 전용 헤더(제목 ‘채팅’, 뒤로가기/메뉴 버튼).
  * 홈의 채팅 버튼을 눌러 채팅 화면으로 이동 가능(프로그램적 네비게이션).

* **접근성**
  * 홈 메뉴 아이콘에 aria-hidden 명시하여 스크린리더 노이즈 감소.

* **라우팅**
  * 채팅 경로(PATH.CHAT) 추가 및 메인 라우트에 전용 헤더와 함께 연결.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->