### PR TITLE
Feat: 게임 결과 페이지 구현

### DIFF
--- a/src/pages/game/page/GameMain.tsx
+++ b/src/pages/game/page/GameMain.tsx
@@ -147,7 +147,7 @@ export default function GameMain() {
           <button
             type="button"
             className={s.imgButton}
-            onClick={() => navigate(`${PATH.GAME}/results`)}
+            onClick={() => navigate(PATH.GAME_RESULTS)}
             aria-label="게임 결과 보러가기"
             title="게임 결과 보러가기"
           >

--- a/src/pages/game/page/GameMain.tsx
+++ b/src/pages/game/page/GameMain.tsx
@@ -1,7 +1,8 @@
+// src/pages/game/GameMain.tsx
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-
 import { PATH } from '@shared/constants/path';
+
 import * as s from './GameMain.css.ts';
 
 /* ✅ 상단 날짜 포맷 (오늘) */

--- a/src/pages/game/page/GameResults.css.ts
+++ b/src/pages/game/page/GameResults.css.ts
@@ -1,69 +1,103 @@
+// src/pages/game/GameResults.css.ts
 import { style } from '@vanilla-extract/css';
+
+//  색상 팔레트
+const bgBox = '#F6F9FE'; // 제목 박스 & 표 배경
+const pillBlue = '#005BBF'; // 시간 알약 색
+const btnBlue = '#A4D5FF'; // 게임 시작 버튼
 
 export const wrap = style({
   minHeight: '100vh',
-  background: '#fff',
-  padding: '32px 20px',
+  background: '#ffffff',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
+  padding: '40px 16px',
+  gap: '24px',
 });
 
-export const title = style({
-  fontSize: '18px',
-  fontWeight: 600,
-  marginBottom: '24px',
-  color: '#333',
+/* 상단 제목 박스 */
+export const titleBox = style({
+  width: 325,
+  height: 84,
+  background: bgBox,
+  borderRadius: 20,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
 });
 
-export const list = style({
-  width: '100%',
-  maxWidth: '320px',
-  background: '#f9f9f9',
-  borderRadius: '12px',
-  padding: '8px 0',
-  marginBottom: '24px',
+export const titleText = style({
+  fontSize: 20,
+  fontWeight: 700,
+  color: '#000',
+  textAlign: 'center',
+});
+
+/* 결과 표 */
+export const listBox = style({
+  width: 325,
+  background: bgBox,
+  borderRadius: 20,
+  padding: '12px 0',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
 });
 
 export const item = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  padding: '12px 20px',
-  borderBottom: '1px solid #e0e0e0',
+  padding: '16px 24px',
+  borderBottom: '1px solid rgba(0,0,0,0.06)',
   selectors: {
     '&:last-child': { borderBottom: 'none' },
   },
 });
 
 export const rank = style({
-  width: '32px',
-  fontWeight: 600,
-  color: '#666',
+  width: 40,
+  fontSize: 16,
+  fontWeight: 500,
+  color: '#333',
 });
 
 export const name = style({
   flex: 1,
-  textAlign: 'left',
+  fontSize: 18,
+  fontWeight: 500,
   color: '#333',
 });
 
-export const time = style({
-  background: '#1976d2',
+export const timePill = style({
+  minWidth: 74,
+  padding: '8px 14px',
+  borderRadius: 999,
+  background: pillBlue,
   color: '#fff',
-  padding: '4px 12px',
-  borderRadius: '20px',
+  fontSize: 16,
   fontWeight: 500,
-  fontSize: '14px',
+  textAlign: 'center',
 });
 
+/* 게임 시작 버튼 */
 export const startBtn = style({
-  width: '200px',
-  height: '44px',
-  borderRadius: '8px',
+  width: 260, // 표(325)보다 작게
+  height: 45,
   border: 'none',
-  background: '#4dabf7',
-  color: '#fff',
-  fontWeight: 600,
+  borderRadius: 16,
+  background: btnBlue,
+  color: '#000',
+  fontSize: 18,
+  fontWeight: 500,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   cursor: 'pointer',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
+  transition: 'transform .05s ease, filter .15s ease',
+  selectors: {
+    '&:hover': { filter: 'brightness(1.05)' },
+    '&:active': { transform: 'translateY(1px)' },
+  },
 });

--- a/src/pages/game/page/GameResults.css.ts
+++ b/src/pages/game/page/GameResults.css.ts
@@ -1,89 +1,69 @@
-// src/pages/game/GameResults.css.ts
 import { style } from '@vanilla-extract/css';
 
 export const wrap = style({
-  minHeight: '100dvh',
-  color: '#fff',
-  background:
-    'linear-gradient(180deg, rgba(22,24,35,1) 0%, rgba(30,32,45,1) 60%, rgba(24,26,36,1) 100%)',
-  padding: '20px 16px 40px',
+  minHeight: '100vh',
+  background: '#fff',
+  padding: '32px 20px',
   display: 'flex',
   flexDirection: 'column',
-  gap: '20px',
-});
-
-export const header = style({
-  display: 'grid',
-  gridTemplateColumns: '40px 1fr 40px',
   alignItems: 'center',
 });
 
-export const backBtn = style({
-  width: 32,
-  height: 32,
-  borderRadius: 8,
-  border: '1px solid rgba(255,255,255,0.2)',
-  background: 'transparent',
-  color: '#fff',
-  cursor: 'pointer',
-});
-
 export const title = style({
-  textAlign: 'center',
-  fontSize: 20,
-  fontWeight: 800,
-  letterSpacing: 0.2,
+  fontSize: '18px',
+  fontWeight: 600,
+  marginBottom: '24px',
+  color: '#333',
 });
 
-export const spacer = style({});
-
-export const cards = style({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  gap: 12,
+export const list = style({
+  width: '100%',
+  maxWidth: '320px',
+  background: '#f9f9f9',
+  borderRadius: '12px',
+  padding: '8px 0',
+  marginBottom: '24px',
 });
 
-export const card = style({
-  background: 'rgba(255,255,255,0.06)',
-  border: '1px solid rgba(255,255,255,0.12)',
-  borderRadius: 16,
-  padding: '14px 12px',
-  textAlign: 'center',
+export const item = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '12px 20px',
+  borderBottom: '1px solid #e0e0e0',
+  selectors: {
+    '&:last-child': { borderBottom: 'none' },
+  },
 });
 
-export const cardLabel = style({
-  fontSize: 12,
-  opacity: 0.8,
-  marginBottom: 6,
+export const rank = style({
+  width: '32px',
+  fontWeight: 600,
+  color: '#666',
 });
 
-export const cardValue = style({
-  fontSize: 18,
-  fontWeight: 800,
+export const name = style({
+  flex: 1,
+  textAlign: 'left',
+  color: '#333',
 });
 
-export const actions = style({
-  marginTop: 'auto',
-  display: 'grid',
-  gap: 10,
+export const time = style({
+  background: '#1976d2',
+  color: '#fff',
+  padding: '4px 12px',
+  borderRadius: '20px',
+  fontWeight: 500,
+  fontSize: '14px',
 });
 
-export const primary = style({
-  height: 44,
-  borderRadius: 12,
+export const startBtn = style({
+  width: '200px',
+  height: '44px',
+  borderRadius: '8px',
   border: 'none',
-  background: '#6C7CFF',
+  background: '#4dabf7',
   color: '#fff',
-  fontWeight: 700,
-  cursor: 'pointer',
-});
-
-export const ghost = style({
-  height: 44,
-  borderRadius: 12,
-  border: '1px solid rgba(255,255,255,0.25)',
-  background: 'transparent',
-  color: '#fff',
-  fontWeight: 700,
+  fontWeight: 600,
   cursor: 'pointer',
 });

--- a/src/pages/game/page/GameResults.css.ts
+++ b/src/pages/game/page/GameResults.css.ts
@@ -22,6 +22,7 @@ export const titleBox = style({
   width: 325,
   height: 84,
   background: bgBox,
+  marginBottom: 20,
   borderRadius: 20,
   display: 'flex',
   alignItems: 'center',
@@ -40,6 +41,7 @@ export const titleText = style({
 export const myCard = style({
   width: 325,
   height: 64,
+  marginBottom: 10,
   background: bgBox,
   borderRadius: 16,
   display: 'grid',
@@ -131,6 +133,7 @@ export const timePill = style({
 export const startBtn = style({
   width: 260,
   height: 45,
+  marginTop: 10,
   border: 'none',
   borderRadius: 16,
   background: btnBlue,
@@ -140,7 +143,7 @@ export const startBtn = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  cursor: 'pointer',
+  //cursor: 'pointer',
   boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
   transition: 'transform .05s ease, filter .15s ease',
   selectors: {

--- a/src/pages/game/page/GameResults.css.ts
+++ b/src/pages/game/page/GameResults.css.ts
@@ -1,0 +1,89 @@
+// src/pages/game/GameResults.css.ts
+import { style } from '@vanilla-extract/css';
+
+export const wrap = style({
+  minHeight: '100dvh',
+  color: '#fff',
+  background:
+    'linear-gradient(180deg, rgba(22,24,35,1) 0%, rgba(30,32,45,1) 60%, rgba(24,26,36,1) 100%)',
+  padding: '20px 16px 40px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '20px',
+});
+
+export const header = style({
+  display: 'grid',
+  gridTemplateColumns: '40px 1fr 40px',
+  alignItems: 'center',
+});
+
+export const backBtn = style({
+  width: 32,
+  height: 32,
+  borderRadius: 8,
+  border: '1px solid rgba(255,255,255,0.2)',
+  background: 'transparent',
+  color: '#fff',
+  cursor: 'pointer',
+});
+
+export const title = style({
+  textAlign: 'center',
+  fontSize: 20,
+  fontWeight: 800,
+  letterSpacing: 0.2,
+});
+
+export const spacer = style({});
+
+export const cards = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: 12,
+});
+
+export const card = style({
+  background: 'rgba(255,255,255,0.06)',
+  border: '1px solid rgba(255,255,255,0.12)',
+  borderRadius: 16,
+  padding: '14px 12px',
+  textAlign: 'center',
+});
+
+export const cardLabel = style({
+  fontSize: 12,
+  opacity: 0.8,
+  marginBottom: 6,
+});
+
+export const cardValue = style({
+  fontSize: 18,
+  fontWeight: 800,
+});
+
+export const actions = style({
+  marginTop: 'auto',
+  display: 'grid',
+  gap: 10,
+});
+
+export const primary = style({
+  height: 44,
+  borderRadius: 12,
+  border: 'none',
+  background: '#6C7CFF',
+  color: '#fff',
+  fontWeight: 700,
+  cursor: 'pointer',
+});
+
+export const ghost = style({
+  height: 44,
+  borderRadius: 12,
+  border: '1px solid rgba(255,255,255,0.25)',
+  background: 'transparent',
+  color: '#fff',
+  fontWeight: 700,
+  cursor: 'pointer',
+});

--- a/src/pages/game/page/GameResults.css.ts
+++ b/src/pages/game/page/GameResults.css.ts
@@ -1,10 +1,11 @@
 // src/pages/game/GameResults.css.ts
 import { style } from '@vanilla-extract/css';
 
-//  색상 팔레트
+// 🎨 색상 가이드
 const bgBox = '#F6F9FE'; // 제목 박스 & 표 배경
-const pillBlue = '#005BBF'; // 시간 알약 색
+const pillBlue = '#005BBF'; // 시간 알약
 const btnBlue = '#A4D5FF'; // 게임 시작 버튼
+const meRowBg = '#EAF3FF'; // 내 순위 행 강조(박스보다 살짝 짙은 파랑 톤)
 
 export const wrap = style({
   minHeight: '100vh',
@@ -12,8 +13,8 @@ export const wrap = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  padding: '40px 16px',
-  gap: '24px',
+  padding: '36px 16px 40px',
+  gap: '16px',
 });
 
 /* 상단 제목 박스 */
@@ -35,37 +36,83 @@ export const titleText = style({
   textAlign: 'center',
 });
 
-/* 결과 표 */
-export const listBox = style({
+/* ===== 내 순위 고정 카드 ===== */
+export const myCard = style({
   width: 325,
+  height: 64,
   background: bgBox,
+  borderRadius: 16,
+  display: 'grid',
+  gridTemplateColumns: '48px 1fr auto',
+  alignItems: 'center',
+  padding: '0 16px 0 20px',
+  gap: 12,
+  border: `1.5px solid ${pillBlue}`, // 선으로 강조
+});
+
+export const rankMe = style({
+  fontSize: 16,
+  fontWeight: 800,
+  color: '#000',
+});
+
+export const nameMe = style({
+  fontSize: 18,
+  fontWeight: 800,
+  color: '#000',
+});
+
+export const timePillMe = style({
+  minWidth: 74,
+  padding: '8px 14px',
+  borderRadius: 999,
+  background: pillBlue,
+  color: '#fff',
+  fontSize: 16,
+  fontWeight: 800,
+  textAlign: 'center',
+});
+
+/* ===== 스크롤 가능한 리스트 ===== */
+export const scrollWrap = style({
+  width: 325,
+  maxHeight: 280, // ✅ 스크롤 영역 높이
+  overflowY: 'auto',
   borderRadius: 20,
-  padding: '12px 0',
+  // 바깥 그림자
   boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
 });
 
+export const listBox = style({
+  background: bgBox,
+  borderRadius: 20,
+  padding: '8px 0',
+});
+
 export const item = style({
-  display: 'flex',
+  display: 'grid',
+  gridTemplateColumns: '48px 1fr auto',
   alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: '16px 24px',
+  padding: '16px 24px 16px 20px',
   borderBottom: '1px solid rgba(0,0,0,0.06)',
   selectors: {
     '&:last-child': { borderBottom: 'none' },
   },
 });
 
+export const itemMe = style({
+  background: meRowBg, // ✅ 내 순위 행 배경 강조
+});
+
 export const rank = style({
-  width: 40,
   fontSize: 16,
-  fontWeight: 500,
+  fontWeight: 600,
   color: '#333',
 });
 
 export const name = style({
-  flex: 1,
   fontSize: 18,
-  fontWeight: 500,
+  fontWeight: 600,
   color: '#333',
 });
 
@@ -76,20 +123,20 @@ export const timePill = style({
   background: pillBlue,
   color: '#fff',
   fontSize: 16,
-  fontWeight: 500,
+  fontWeight: 700,
   textAlign: 'center',
 });
 
-/* 게임 시작 버튼 */
+/* 게임 시작 버튼 (표보다 작게) */
 export const startBtn = style({
-  width: 260, // 표(325)보다 작게
+  width: 260,
   height: 45,
   border: 'none',
   borderRadius: 16,
   background: btnBlue,
   color: '#000',
   fontSize: 18,
-  fontWeight: 500,
+  fontWeight: 700,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/src/pages/game/page/GameResults.tsx
+++ b/src/pages/game/page/GameResults.tsx
@@ -1,0 +1,49 @@
+// src/pages/game/GameResults.tsx
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@shared/constants/path';
+import * as s from './GameResults.css';
+
+export default function GameResults() {
+  const nav = useNavigate();
+
+  // TODO: 실제 결과 데이터 주입
+  const totalPlays = 12;
+  const correct = 9;
+  const accuracy = Math.round((correct / totalPlays) * 100);
+
+  return (
+    <div className={s.wrap}>
+      <header className={s.header}>
+        <button className={s.backBtn} onClick={() => nav(PATH.GAME)} aria-label="게임으로 돌아가기">
+          ←
+        </button>
+        <h1 className={s.title}>게임 결과</h1>
+        <div className={s.spacer} />
+      </header>
+
+      <section className={s.cards}>
+        <div className={s.card}>
+          <p className={s.cardLabel}>총 플레이</p>
+          <p className={s.cardValue}>{totalPlays}회</p>
+        </div>
+        <div className={s.card}>
+          <p className={s.cardLabel}>정답</p>
+          <p className={s.cardValue}>{correct}개</p>
+        </div>
+        <div className={s.card}>
+          <p className={s.cardLabel}>정확도</p>
+          <p className={s.cardValue}>{accuracy}%</p>
+        </div>
+      </section>
+
+      <section className={s.actions}>
+        <button className={s.primary} onClick={() => nav(PATH.GAME)}>
+          다시 하기
+        </button>
+        <button className={s.ghost} onClick={() => nav(PATH.ROOT)}>
+          홈으로
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/game/page/GameResults.tsx
+++ b/src/pages/game/page/GameResults.tsx
@@ -1,49 +1,36 @@
-// src/pages/game/GameResults.tsx
 import { useNavigate } from 'react-router-dom';
-import { PATH } from '@shared/constants/path';
 import * as s from './GameResults.css';
+import { PATH } from '@shared/constants/path';
 
 export default function GameResults() {
-  const nav = useNavigate();
+  const navigate = useNavigate();
 
-  // TODO: 실제 결과 데이터 주입
-  const totalPlays = 12;
-  const correct = 9;
-  const accuracy = Math.round((correct / totalPlays) * 100);
+  // 임시 데이터 (실제 데이터로 교체 가능)
+  const players = [
+    { id: '01', name: '양서연', time: '05:20' },
+    { id: '02', name: '임지수', time: '05:20' },
+    { id: '03', name: '조소율', time: '05:20' },
+    { id: '04', name: '홍다인', time: '05:20' },
+    { id: '18', name: '소원', time: '05:20' },
+  ];
 
   return (
     <div className={s.wrap}>
-      <header className={s.header}>
-        <button className={s.backBtn} onClick={() => nav(PATH.GAME)} aria-label="게임으로 돌아가기">
-          ←
-        </button>
-        <h1 className={s.title}>게임 결과</h1>
-        <div className={s.spacer} />
-      </header>
+      <h1 className={s.title}>게임 결과입니다.</h1>
 
-      <section className={s.cards}>
-        <div className={s.card}>
-          <p className={s.cardLabel}>총 플레이</p>
-          <p className={s.cardValue}>{totalPlays}회</p>
-        </div>
-        <div className={s.card}>
-          <p className={s.cardLabel}>정답</p>
-          <p className={s.cardValue}>{correct}개</p>
-        </div>
-        <div className={s.card}>
-          <p className={s.cardLabel}>정확도</p>
-          <p className={s.cardValue}>{accuracy}%</p>
-        </div>
-      </section>
+      <ul className={s.list}>
+        {players.map((p) => (
+          <li key={p.id} className={s.item}>
+            <span className={s.rank}>{p.id}</span>
+            <span className={s.name}>{p.name}</span>
+            <span className={s.time}>{p.time}</span>
+          </li>
+        ))}
+      </ul>
 
-      <section className={s.actions}>
-        <button className={s.primary} onClick={() => nav(PATH.GAME)}>
-          다시 하기
-        </button>
-        <button className={s.ghost} onClick={() => nav(PATH.ROOT)}>
-          홈으로
-        </button>
-      </section>
+      <button className={s.startBtn} onClick={() => navigate(PATH.GAME)}>
+        게임 시작
+      </button>
     </div>
   );
 }

--- a/src/pages/game/page/GameResults.tsx
+++ b/src/pages/game/page/GameResults.tsx
@@ -1,20 +1,36 @@
 // src/pages/game/GameResults.tsx
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { PATH } from '@shared/constants/path';
 
 import * as s from './GameResults.css.ts';
 
+type Player = { id: string; name: string; time: string };
+
 export default function GameResults() {
   const navigate = useNavigate();
 
-  // 실제 데이터는 서버 연동 시 교체
-  const players = [
+  // 👉 더미 데이터 (순위 1~10 가정)
+  const allPlayers: Player[] = [
     { id: '01', name: '양서연', time: '05:20' },
     { id: '02', name: '임지수', time: '05:20' },
     { id: '03', name: '조소율', time: '05:20' },
     { id: '04', name: '홍다인', time: '05:20' },
-    { id: '18', name: '소원', time: '05:20' },
+    { id: '05', name: '한가람', time: '05:20' },
+    { id: '06', name: '정하린', time: '05:20' },
+    { id: '07', name: '김민재', time: '05:20' },
+    { id: '08', name: '소원', time: '05:20' }, // ← 현재 사용자
+    { id: '09', name: '박지연', time: '05:20' },
+    { id: '10', name: '최도윤', time: '05:20' },
   ];
+
+  // 현재 사용자 (요청: 사용자를 8위로 가정)
+  const myId = '08';
+  const me = useMemo(() => allPlayers.find((p) => p.id === myId)!, [allPlayers]);
+
+  // 스크롤 리스트는 1~10 전체를 그대로 보여줌
+  const playersForList = allPlayers;
 
   return (
     <div className={s.wrap}>
@@ -23,16 +39,28 @@ export default function GameResults() {
         <h1 className={s.titleText}>게임 결과입니다.</h1>
       </div>
 
-      {/* 결과 표 */}
-      <ul className={s.listBox}>
-        {players.map((p) => (
-          <li key={p.id} className={s.item}>
-            <span className={s.rank}>{p.id}</span>
-            <span className={s.name}>{p.name}</span>
-            <span className={s.timePill}>{p.time}</span>
-          </li>
-        ))}
-      </ul>
+      {/* ✅ 스크롤 전에도 '내 순위'가 보이도록 고정 카드 */}
+      <div className={s.myCard} aria-label="내 순위">
+        <span className={s.rankMe}>{me.id}</span>
+        <span className={s.nameMe}>{me.name}</span>
+        <span className={s.timePillMe}>{me.time}</span>
+      </div>
+
+      {/* ✅ 스크롤 가능한 전체 결과표 */}
+      <div className={s.scrollWrap}>
+        <ul className={s.listBox}>
+          {playersForList.map((p) => {
+            const isMe = p.id === myId;
+            return (
+              <li key={p.id} className={`${s.item} ${isMe ? s.itemMe : ''}`}>
+                <span className={isMe ? s.rankMe : s.rank}>{p.id}</span>
+                <span className={isMe ? s.nameMe : s.name}>{p.name}</span>
+                <span className={isMe ? s.timePillMe : s.timePill}>{p.time}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
 
       {/* 게임 시작 버튼 */}
       <button className={s.startBtn} onClick={() => navigate(PATH.GAME)}>

--- a/src/pages/game/page/GameResults.tsx
+++ b/src/pages/game/page/GameResults.tsx
@@ -1,11 +1,13 @@
+// src/pages/game/GameResults.tsx
 import { useNavigate } from 'react-router-dom';
-import * as s from './GameResults.css';
 import { PATH } from '@shared/constants/path';
+
+import * as s from './GameResults.css.ts';
 
 export default function GameResults() {
   const navigate = useNavigate();
 
-  // 임시 데이터 (실제 데이터로 교체 가능)
+  // 실제 데이터는 서버 연동 시 교체
   const players = [
     { id: '01', name: '양서연', time: '05:20' },
     { id: '02', name: '임지수', time: '05:20' },
@@ -16,18 +18,23 @@ export default function GameResults() {
 
   return (
     <div className={s.wrap}>
-      <h1 className={s.title}>게임 결과입니다.</h1>
+      {/* 상단 제목 박스 */}
+      <div className={s.titleBox}>
+        <h1 className={s.titleText}>게임 결과입니다.</h1>
+      </div>
 
-      <ul className={s.list}>
+      {/* 결과 표 */}
+      <ul className={s.listBox}>
         {players.map((p) => (
           <li key={p.id} className={s.item}>
             <span className={s.rank}>{p.id}</span>
             <span className={s.name}>{p.name}</span>
-            <span className={s.time}>{p.time}</span>
+            <span className={s.timePill}>{p.time}</span>
           </li>
         ))}
       </ul>
 
+      {/* 게임 시작 버튼 */}
       <button className={s.startBtn} onClick={() => navigate(PATH.GAME)}>
         게임 시작
       </button>

--- a/src/pages/game/page/GameResults.tsx
+++ b/src/pages/game/page/GameResults.tsx
@@ -1,7 +1,6 @@
 // src/pages/game/GameResults.tsx
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-
 import { PATH } from '@shared/constants/path';
 
 import * as s from './GameResults.css.ts';
@@ -15,7 +14,7 @@ export default function GameResults() {
   const allPlayers: Player[] = [
     { id: '01', name: '양서연', time: '05:20' },
     { id: '02', name: '임지수', time: '05:20' },
-    { id: '03', name: '조소율', time: '05:20' },
+    { id: '03', name: '조소윤', time: '05:20' },
     { id: '04', name: '홍다인', time: '05:20' },
     { id: '05', name: '한가람', time: '05:20' },
     { id: '06', name: '정하린', time: '05:20' },

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -9,6 +9,7 @@ export const PATH = {
   SCHEDULE: '/schedule',
   GAME: '/game',
   GAME_MAIN: '/game/main',
+  GAME_RESULTS: '/game/results',
 } as const;
 
 export const SIGNUP_STEPS = {

--- a/src/shared/routes/MainRoutes.tsx
+++ b/src/shared/routes/MainRoutes.tsx
@@ -21,6 +21,7 @@ import ChatList from '@/pages/chat/page/ChatList';
 import Schedule from '@/pages/schedule/page/Schedule';
 import Game from '@/pages/game/page/Game';
 import GameMain from '@/pages/game/page/GameMain';
+import GameResults from '@/pages/game/page/GameResults';
 
 export const MainRoutes: RouteObject[] = [
   // 기본 헤더
@@ -93,5 +94,10 @@ export const MainRoutes: RouteObject[] = [
   {
     element: <Layout header={<PageHeader title="게임" />} />,
     children: [{ path: PATH.GAME_MAIN, element: <GameMain /> }],
+  },
+  //게임 결과
+  {
+    element: <Layout header={<PageHeader title="게임 결과" />} />,
+    children: [{ path: PATH.GAME_RESULTS, element: <GameResults /> }],
   },
 ];


### PR DESCRIPTION
# 🐣 Pull requests

### 📍 작업한 이슈번호

- #48 

### 💻 작업한 내용

- GameResults 페이지 신규 구현
- 결과 표 디자인 & 기능
  - 전체 순위(더미 10명) 스크롤 가능하도록 maxHeight + overflow-y 적용
  - 사용자(예: 소원, id:08) 행을 EAF3FF 배경과 Bold 처리로 강조
  - 스크롤 전에도 내 순위가 항상 보이도록 별도 고정 카드 추가

### 📢 PR Point

- 임의로 변경한 디자인 괜찮은지 확인
- 다른사람 모니터에서도 표 길이 적당한지, 전체 화면 비율 괜찮은지 확인


### 📸 스크린샷
<img width="585" height="863" alt="image" src="https://github.com/user-attachments/assets/0e603058-e07d-44e7-8cfd-9b9abb0a3d74" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 게임 결과 페이지 추가: 내 순위 카드와 전체 순위 리스트 제공, 현재 사용자 행 강조 표시.
  - 결과 화면에서 ‘게임 시작’ 버튼으로 바로 새 게임 진행 가능.
- 스타일
  - 결과 화면 전용 디자인 적용: 카드형 레이아웃, 스크롤 가능한 순위 리스트, 강조 색상 및 버튼 상태 추가.
- 라우팅
  - 게임 결과 전용 경로 추가로 접근성 향상.
- 기타
  - 게임 메인에서 결과 보기 버튼의 내비게이션 연결 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->